### PR TITLE
fix: support PDF/PPTX upload and resolve file upload issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,9 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 
+# Claude Code
+CLAUDE.md
+
 # Marimo
 marimo/_static/
 marimo/_lsp/

--- a/frontend-workflow/src/components/Paper2GraphPage.tsx
+++ b/frontend-workflow/src/components/Paper2GraphPage.tsx
@@ -411,14 +411,22 @@ const Paper2FigurePage = () => {
         // Fetch PPT file and upload to Supabase Storage
         if (data.ppt_filename) {
           try {
+            console.log('[Paper2GraphPage] Fetching tech_route file from:', data.ppt_filename);
             const pptRes = await fetch(data.ppt_filename);
-            if (pptRes.ok) {
-              const pptBlob = await pptRes.blob();
-              const pptName = data.ppt_filename.split('/').pop() || 'tech_route.pptx';
-              uploadAndSaveFile(pptBlob, pptName, 'paper2figure');
+            if (!pptRes.ok) {
+              throw new Error(`HTTP ${pptRes.status}: ${pptRes.statusText}`);
+            }
+            const pptBlob = await pptRes.blob();
+            const pptName = data.ppt_filename.split('/').pop() || 'tech_route.pptx';
+            console.log('[Paper2GraphPage] Uploading tech_route file to storage:', pptName);
+            const uploadResult = await uploadAndSaveFile(pptBlob, pptName, 'paper2figure');
+            if (uploadResult) {
+              console.log('[Paper2GraphPage] Tech_route file uploaded successfully:', uploadResult.file_name);
+            } else {
+              console.warn('[Paper2GraphPage] Tech_route file upload skipped or failed');
             }
           } catch (e) {
-            console.warn('[Paper2GraphPage] Failed to upload tech_route file:', e);
+            console.error('[Paper2GraphPage] Failed to upload tech_route file:', e);
           }
         }
       } else {
@@ -460,7 +468,14 @@ const Paper2FigurePage = () => {
         // Record usage and save file to Supabase Storage
         await recordUsage(user?.id || null, 'paper2figure');
         refreshQuota();
-        uploadAndSaveFile(blob, filename, 'paper2figure');
+
+        console.log('[Paper2GraphPage] Uploading file to storage:', filename);
+        const uploadResult = await uploadAndSaveFile(blob, filename, 'paper2figure');
+        if (uploadResult) {
+          console.log('[Paper2GraphPage] File uploaded successfully:', uploadResult.file_name);
+        } else {
+          console.warn('[Paper2GraphPage] File upload skipped or failed');
+        }
 
         const a = document.createElement('a');
         a.href = url;

--- a/frontend-workflow/src/components/Ppt2PolishPage.tsx
+++ b/frontend-workflow/src/components/Ppt2PolishPage.tsx
@@ -982,15 +982,24 @@ const Ppt2PolishPage = () => {
       await recordUsage(user?.id || null, 'ppt2polish');
       refreshQuota();
 
-      // Fetch PPT file and upload to Supabase Storage
-      if (pptxUrl) {
+      // Upload generated file to Supabase Storage (either PPTX or PDF)
+      // Prefer PPTX, fallback to PDF
+      let fileUrl = pptxUrl;
+      let defaultName = 'ppt2polish_result.pptx';
+
+      if (!fileUrl && pdfUrl) {
+        fileUrl = pdfUrl;
+        defaultName = 'ppt2polish_result.pdf';
+      }
+
+      if (fileUrl) {
         try {
-          const pptRes = await fetch(pptxUrl);
-          if (pptRes.ok) {
-            const pptBlob = await pptRes.blob();
-            const pptName = pptxUrl.split('/').pop() || 'ppt2polish_result.pptx';
-            console.log('[Ppt2PolishPage] Uploading file to storage:', pptName);
-            await uploadAndSaveFile(pptBlob, pptName, 'ppt2polish');
+          const fileRes = await fetch(fileUrl);
+          if (fileRes.ok) {
+            const fileBlob = await fileRes.blob();
+            const fileName = fileUrl.split('/').pop() || defaultName;
+            console.log('[Ppt2PolishPage] Uploading file to storage:', fileName);
+            await uploadAndSaveFile(fileBlob, fileName, 'ppt2polish');
             console.log('[Ppt2PolishPage] File uploaded successfully');
           }
         } catch (e) {


### PR DESCRIPTION
## Summary

Fix file upload issues for Paper2Any workflows and add support for both PPTX and PDF formats.

## Changes

### 1. Resolve Supabase file upload failures (commit: ab382a25)
- **Root cause**: Supabase Storage rejects keys with non-ASCII characters and spaces
- **Fix**: Add `sanitizeFileName()` function to clean filenames
  - Replace spaces with underscores
  - Remove non-ASCII characters (Chinese, special chars)
  - Fallback to `workflow_timestamp.ext` for all-Chinese filenames
- **Affected workflows**: Paper2Figure, Paper2PPT, PDF2PPT, PptPolish
- **Added**: `await` to `uploadAndSaveFile()` calls to ensure proper execution

### 2. Support both PPTX and PDF file upload (commit: 36ee84f9)
- **Root cause**: Backend may return either PPTX or PDF depending on workflow state
- **Fix**: Update upload logic to handle both formats
  - Prefer PPTX, fallback to PDF if PPTX not available
  - Exclude input PDFs from search results
- **Affected files**: 
  - `Paper2PptPage.tsx` (handleGenerateFinal)
  - `Ppt2PolishPage.tsx` (handleGenerateFinal)

### 3. Update CLAUDE.md
- Add remote server SSH configuration for debugging
- Document port mapping setup

## Testing

- ✅ Paper2Figure: File upload successful
- ✅ Paper2PPT: File upload successful (both PPTX and PDF)
- ✅ PDF2PPT: File upload successful
- ✅ PptPolish: File upload successful (both PPTX and PDF)
- ✅ Files appear correctly in MyFiles page

## Notes

- Based on latest `lz/dev` branch (rebased)
- All workflows now properly save files to Supabase Storage
- Filenames with Chinese characters are properly sanitized

🤖 Generated with [Claude Code](https://claude.com/claude-code)