### PR TITLE
fix: replace 12 bare excepts with except Exception

### DIFF
--- a/dataflow_agent/agentroles/paper2any_agents/table_text_renderer.py
+++ b/dataflow_agent/agentroles/paper2any_agents/table_text_renderer.py
@@ -311,7 +311,7 @@ def _render_table_fallback(
                 try:
                     cell = table[(i, j)]
                     cell.set_facecolor('#D9E2F3' if i % 2 == 0 else 'white')
-                except:
+                except Exception:
                     pass
         
         plt.savefig(str(output_path), dpi=150, bbox_inches='tight', facecolor='white')

--- a/dataflow_agent/graphbuilder/message_history.py
+++ b/dataflow_agent/graphbuilder/message_history.py
@@ -650,7 +650,7 @@ class AdvancedMessageHistory:
             if checkpoint and hasattr(checkpoint, 'id'):
                 return checkpoint.id
             return None
-        except:
+        except Exception:
             return None
 
     def get_message_history(

--- a/dataflow_agent/promptstemplates/prompts_repo.py
+++ b/dataflow_agent/promptstemplates/prompts_repo.py
@@ -1086,7 +1086,7 @@ Produce complete, runnable Python code that:
 [OUTPUT RULES]
 Return only a JSON object with a single key:
 {"code": "<complete runnable source code>"}
-No comments, no extra keys, no extra prints except:
+No comments, no extra keys, no extra prints except Exception:
 - one line: [selected_input_key] <the_key>
 - up to two lines: [preview_output] <result>
 """

--- a/dataflow_agent/toolkits/pipetool/pipe_tools.py
+++ b/dataflow_agent/toolkits/pipetool/pipe_tools.py
@@ -654,7 +654,7 @@ def group_import_for_full_params(op_names: List[str]) -> tuple:
 #             try:
 #                 run_sig = inspect.signature(cls.run)
 #                 run_has_storage = "storage" in run_sig.parameters
-#             except:
+#             except Exception:
 #                 pass
 
 #         # -------- 渲染 __init__ 参数 --------
@@ -742,7 +742,7 @@ def render_operator_blocks_with_full_params(
                 init_sig = inspect.signature(cls.__init__)
                 init_param_names = {p.name for p in list(init_sig.parameters.values())[1:] 
                                    if p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)}
-            except:
+            except Exception:
                 pass
             
             try:
@@ -750,7 +750,7 @@ def render_operator_blocks_with_full_params(
                 run_param_names = {p.name for p in list(run_sig.parameters.values())[1:] 
                                   if p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
                                   and p.name != "storage"}
-            except:
+            except Exception:
                 pass
             
             # 分配参数
@@ -778,7 +778,7 @@ def render_operator_blocks_with_full_params(
             try:
                 run_sig = inspect.signature(cls.run)
                 run_has_storage = "storage" in run_sig.parameters
-            except:
+            except Exception:
                 pass
 
         # -------- 渲染 __init__ 参数 --------

--- a/dataflow_agent/workflow/wf_intelligent_qa.py
+++ b/dataflow_agent/workflow/wf_intelligent_qa.py
@@ -161,7 +161,7 @@ def create_intelligent_qa_graph() -> GenericGraphBuilder:
                     try:
                         with open(file_path, "r", encoding="utf-8") as f:
                             raw_content = f.read()
-                    except:
+                    except Exception:
                         raw_content = "[Unsupported file type]"
 
                 # ==========================

--- a/dataflow_agent/workflow/wf_kb_mindmap.py
+++ b/dataflow_agent/workflow/wf_kb_mindmap.py
@@ -134,7 +134,7 @@ def create_kb_mindmap_graph() -> GenericGraphBuilder:
                     try:
                         with open(file_path, "r", encoding="utf-8") as f:
                             raw_content = f.read()
-                    except:
+                    except Exception:
                         raw_content = "[Unsupported file type]"
 
             except Exception as e:

--- a/dataflow_agent/workflow/wf_kb_podcast.py
+++ b/dataflow_agent/workflow/wf_kb_podcast.py
@@ -143,7 +143,7 @@ def create_kb_podcast_graph() -> GenericGraphBuilder:
                     try:
                         with open(file_path, "r", encoding="utf-8") as f:
                             raw_content = f.read()
-                    except:
+                    except Exception:
                         raw_content = "[Unsupported file type]"
 
             except Exception as e:

--- a/dataflow_agent/workflow/wf_pdf2ppt_optimized.py
+++ b/dataflow_agent/workflow/wf_pdf2ppt_optimized.py
@@ -1007,7 +1007,7 @@ def create_pdf2ppt_optimized_graph() -> GenericGraphBuilder:
                                 with Image.open(img_path) as page_img:
                                     crop = page_img.crop((x1, y1, x2, y2))
                                     crop.save(ipath)
-                            except:
+                            except Exception:
                                 ipath = None
                     
                     if ipath and os.path.exists(ipath):

--- a/fastapi_app/services/rebuttal_service.py
+++ b/fastapi_app/services/rebuttal_service.py
@@ -1878,7 +1878,7 @@ class RebuttalService:
                     # Save error state
                     try:
                         self._save_session_summary(session_id)
-                    except:
+                    except Exception:
                         pass
                     return (idx, session.questions[idx])
                 # Return empty state if session is gone


### PR DESCRIPTION
Replace 12 bare `except:` with `except Exception:` across 9 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.