### PR TITLE
feat: support saved inline edits and content-based slide regeneration in paper2ppt

### DIFF
--- a/dataflow_agent/state.py
+++ b/dataflow_agent/state.py
@@ -382,6 +382,8 @@ class Paper2FigureState(MainState):
     edit_page_num: int = -1
     # 二次编辑提示词（用于 edit_page_num 对应页）
     edit_page_prompt: str = ""
+    # 是否按当前页的结构化文字内容重生成该页，而不是基于旧图做提示词微调
+    regenerate_from_outline: bool = False
     # PPT/PDF 转图片时的渲染 DPI（None 表示默认）
     render_dpi: Optional[int] = None
     # 批量生成出来的页面图片路径（0-based 对齐 pagecontent）

--- a/dataflow_agent/workflow/wf_paper2ppt_parallel_consistent_style.py
+++ b/dataflow_agent/workflow/wf_paper2ppt_parallel_consistent_style.py
@@ -200,6 +200,137 @@ def _extract_image_path_from_pagecontent_item(item: Any) -> Optional[str]:
     return None
 
 
+async def _regenerate_single_page_from_content(
+    state: Paper2FigureState,
+    idx: int,
+    item: Dict[str, Any],
+    save_path: str,
+    ref_img_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    async def _call_image_api_with_retry(coro_factory, retries: int = 3, delay: float = 1.0) -> bool:
+        last_err: Optional[Exception] = None
+        for attempt in range(1, retries + 1):
+            try:
+                await coro_factory()
+                return True
+            except Exception as e:  # noqa: BLE001
+                last_err = e
+                log.error(f"[paper2ppt] single page regen failed attempt {attempt}/{retries}: {e}")
+                if attempt < retries:
+                    try:
+                        await asyncio.sleep(delay)
+                    except Exception:
+                        pass
+        log.error(f"[paper2ppt] single page regen failed after {retries} attempts. last_err={last_err}")
+        return False
+
+    style = getattr(state.request, "style", None) or "kartoon"
+    aspect_ratio = getattr(state, "aspect_ratio", None) or "16:9"
+    image_resolution = getattr(state.request, "image_resolution", None) or "2K"
+
+    style_hint = ""
+    if style and style.strip() and style.strip().lower() != "kartoon":
+        style_hint = f"\nAdditional style guidance: {style.strip()}\n"
+
+    base_content, asset_path, is_edit_originally = await _make_prompt_for_structured_page(
+        item,
+        style=style,
+        state=state,
+    )
+
+    use_ref = bool(ref_img_path and os.path.exists(ref_img_path))
+
+    if use_ref:
+        if is_edit_originally and asset_path:
+            final_prompt = (
+                f"{base_content}\n\n"
+                f"--------------------------------------------------\n"
+                f"TASK: Generate a {style} presentation slide.\n"
+                f"INPUT IMAGES:\n"
+                f"  - IMAGE 1 (First Image): STYLE REFERENCE. Strictly follow its color palette, and background style.\n"
+                f"  - IMAGE 2 (Second Image): CONTENT ASSET. Incorporate the chart/table/figure from this image into the slide.\n\n"
+                f"INSTRUCTION: Create a cohesive slide that presents the content from Image 2 but looks exactly like it belongs to the deck of Image 1.\n"
+                f"{style_hint}"
+                f"Language: {state.request.language}"
+            )
+            mode = "regen_multi_edit_ref_asset"
+            ok = await _call_image_api_with_retry(
+                lambda: gemini_multi_image_edit_async(
+                    prompt=final_prompt,
+                    image_paths=[ref_img_path, asset_path],
+                    save_path=save_path,
+                    api_url=state.request.chat_api_url,
+                    api_key=state.request.chat_api_key or os.getenv("DF_API_KEY"),
+                    model=state.request.gen_fig_model,
+                    aspect_ratio=aspect_ratio,
+                    resolution=image_resolution,
+                )
+            )
+        else:
+            final_prompt = (
+                f"{base_content}\n\n"
+                f"Reference the style of the provided image (layout, color, background), "
+                f"but generate NEW CONTENT based on the text description above. "
+                f"Keep the background style consistent.\n"
+                f"{style_hint}"
+                f"Language: {state.request.language}"
+            )
+            mode = "regen_ref_style"
+            ok = await _call_image_api_with_retry(
+                lambda: generate_or_edit_and_save_image_async(
+                    prompt=final_prompt,
+                    save_path=save_path,
+                    aspect_ratio=aspect_ratio,
+                    api_url=state.request.chat_api_url,
+                    api_key=state.request.chat_api_key or os.getenv("DF_API_KEY"),
+                    model=state.request.gen_fig_model,
+                    image_path=ref_img_path,
+                    use_edit=True,
+                    resolution=image_resolution,
+                )
+            )
+    else:
+        if is_edit_originally:
+            final_prompt = (
+                f"{base_content}\n\n"
+                f"根据上述内容绘制ppt，把这个图作为PPT的一部分。生成{style}风格的PPT. \n "
+                f"使用语言：{state.request.language} !!!"
+            )
+        else:
+            final_prompt = (
+                f"{base_content}\n\n"
+                f"根据上述内容。生成{style}风格的 PPT 图像, \n "
+                f"使用语言：{state.request.language}"
+            )
+
+        mode = "regen_origin_edit" if is_edit_originally else "regen_origin_gen"
+        ok = await _call_image_api_with_retry(
+            lambda: generate_or_edit_and_save_image_async(
+                prompt=final_prompt,
+                save_path=save_path,
+                aspect_ratio=aspect_ratio,
+                api_url=state.request.chat_api_url,
+                api_key=state.request.chat_api_key or os.getenv("DF_API_KEY"),
+                model=state.request.gen_fig_model,
+                image_path=asset_path,
+                use_edit=is_edit_originally,
+                resolution=image_resolution,
+            )
+        )
+
+    if not ok:
+        raise ValueError(f"[paper2ppt] failed to regenerate page from outline: idx={idx}")
+
+    out_item = dict(item)
+    out_item.update({
+        "generated_img_path": save_path,
+        "page_idx": idx,
+        "mode": mode,
+        "style": style,
+    })
+    return out_item
+
+
 @register("paper2ppt_parallel_consistent_style")
 def create_paper2ppt_parallel_consistent_graph() -> GenericGraphBuilder:  # noqa: N802
     """
@@ -225,6 +356,8 @@ def create_paper2ppt_parallel_consistent_graph() -> GenericGraphBuilder:  # noqa
     def _route(state: Paper2FigureState) -> str:
         if getattr(state.request, "all_edited_down", False):
             return "export_ppt_assets"
+        if getattr(state, "regenerate_from_outline", False):
+            return "regenerate_single_page_from_content"
         if not getattr(state, "gen_down", False):
             return "generate_pages"
         return "edit_single_page"
@@ -706,6 +839,81 @@ def create_paper2ppt_parallel_consistent_graph() -> GenericGraphBuilder:  # noqa
         state.edit_page_num = -1
         return state
 
+    async def regenerate_single_page_from_content(state: Paper2FigureState) -> Paper2FigureState:
+        idx = int(getattr(state, "edit_page_num", -1))
+        if idx < 0:
+            raise ValueError("[paper2ppt] edit_page_num 必须是 0-based 且 >=0")
+
+        page_items = state.pagecontent or []
+        if idx >= len(page_items):
+            raise ValueError(f"[paper2ppt] 页面索引超出范围: idx={idx}, total={len(page_items)}")
+
+        item = page_items[idx]
+        if not isinstance(item, dict):
+            raise ValueError(f"[paper2ppt] 当前页面缺少结构化内容，无法按内容重生成: idx={idx}")
+
+        result_root = Path(_ensure_result_path(state))
+        img_dir = result_root / "ppt_pages"
+        img_dir.mkdir(parents=True, exist_ok=True)
+
+        user_ref_img = getattr(state.request, "ref_img", None)
+        ref_img_path: Optional[str] = None
+        if user_ref_img:
+            candidate = _abs_path(str(user_ref_img))
+            if os.path.exists(candidate):
+                ref_img_path = candidate
+            else:
+                log.warning(f"[paper2ppt] regenerate_from_outline ref_img not found: {candidate}")
+
+        if not ref_img_path and idx > 0:
+            anchor_path = ""
+            if page_items and isinstance(page_items[0], dict):
+                anchor_path = str(page_items[0].get("generated_img_path") or "")
+            if not anchor_path and getattr(state, "generated_pages", None):
+                anchor_path = state.generated_pages[0] if len(state.generated_pages) > 0 else ""
+            anchor_path = _abs_path(anchor_path) if anchor_path else ""
+            if anchor_path and os.path.exists(anchor_path):
+                ref_img_path = anchor_path
+
+        temp_save_path = str((img_dir / f"page_{idx:03d}_temp.png").resolve())
+        regenerated_item = await _regenerate_single_page_from_content(
+            state=state,
+            idx=idx,
+            item=item,
+            save_path=temp_save_path,
+            ref_img_path=ref_img_path,
+        )
+
+        version_prompt = "Regenerated from current page content"
+        versioned_path, version_num = ImageVersionManager.save_versioned_image(
+            img_dir=img_dir,
+            page_idx=idx,
+            new_image_path=temp_save_path,
+            prompt=version_prompt,
+        )
+
+        temp_path_obj = Path(temp_save_path)
+        if temp_path_obj.exists():
+            temp_path_obj.unlink()
+
+        save_path = str((img_dir / f"page_{idx:03d}.png").resolve())
+
+        state.generated_pages = state.generated_pages or []
+        while len(state.generated_pages) < len(page_items):
+            state.generated_pages.append("")
+        state.generated_pages[idx] = save_path
+
+        regenerated_item["generated_img_path"] = save_path
+        regenerated_item["mode"] = "regenerate_from_content"
+        regenerated_item["current_version"] = version_num
+        regenerated_item["versioned_img_path"] = versioned_path
+        state.pagecontent[idx] = regenerated_item
+
+        state.regenerate_from_outline = False
+        state.edit_page_prompt = ""
+        state.edit_page_num = -1
+        return state
+
     async def export_ppt_assets(state: Paper2FigureState) -> Paper2FigureState:
         """
         导出节点 (同 paper2ppt_parallel)
@@ -740,6 +948,7 @@ def create_paper2ppt_parallel_consistent_graph() -> GenericGraphBuilder:  # noqa
         "_start_": _start_,
         "generate_pages": generate_pages,
         "edit_single_page": edit_single_page,
+        "regenerate_single_page_from_content": regenerate_single_page_from_content,
         "export_ppt_assets": export_ppt_assets,
         "_end_": lambda state: state,
     }
@@ -747,6 +956,7 @@ def create_paper2ppt_parallel_consistent_graph() -> GenericGraphBuilder:  # noqa
     edges = [
         ("generate_pages", "export_ppt_assets"),
         ("edit_single_page", "export_ppt_assets"),
+        ("regenerate_single_page_from_content", "export_ppt_assets"),
         ("export_ppt_assets", "_end_"),
     ]
 

--- a/fastapi_app/routers/paper2ppt.py
+++ b/fastapi_app/routers/paper2ppt.py
@@ -117,6 +117,7 @@ async def paper2ppt_ppt_json(
     page_id: Optional[int] = Form(None),
     # 页面编辑提示词（get_down=true 时必传）
     edit_prompt: Optional[str] = Form(None),
+    regenerate_from_outline: str = Form("false"),
     service: Paper2PPTService = Depends(get_service),
 ):
     """
@@ -140,6 +141,7 @@ async def paper2ppt_ppt_json(
         pagecontent=pagecontent,
         page_id=page_id,
         edit_prompt=edit_prompt,
+        regenerate_from_outline=regenerate_from_outline,
         image_resolution=image_resolution,
     )
 
@@ -173,6 +175,7 @@ async def paper2ppt_generate_task(
     pagecontent: Optional[str] = Form(None),
     page_id: Optional[int] = Form(None),
     edit_prompt: Optional[str] = Form(None),
+    regenerate_from_outline: str = Form("false"),
     task_service: Paper2PPTTaskService = Depends(get_task_service),
 ):
     req = PPTGenerationRequest(
@@ -190,6 +193,7 @@ async def paper2ppt_generate_task(
         pagecontent=pagecontent,
         page_id=page_id,
         edit_prompt=edit_prompt,
+        regenerate_from_outline=regenerate_from_outline,
         image_resolution=image_resolution,
     )
     return await task_service.submit_generate_task(req=req, reference_img=reference_img)

--- a/fastapi_app/schemas.py
+++ b/fastapi_app/schemas.py
@@ -469,6 +469,7 @@ class PPTGenerationRequest(BaseModel):
     pagecontent: Optional[str] = None
     page_id: Optional[int] = None
     edit_prompt: Optional[str] = None
+    regenerate_from_outline: str = "false"
     # 图像生成分辨率（1K/2K/4K 等）
     image_resolution: Optional[str] = None
 

--- a/fastapi_app/services/paper2ppt_service.py
+++ b/fastapi_app/services/paper2ppt_service.py
@@ -288,12 +288,15 @@ class Paper2PPTService:
         # 转换字符串布尔值
         get_down_bool = str(req.get_down).lower() in ("true", "1", "yes")
         all_edited_down_bool = str(req.all_edited_down).lower() in ("true", "1", "yes")
+        regenerate_from_outline_bool = str(req.regenerate_from_outline).lower() in ("true", "1", "yes")
 
         # 校验编辑/生成模式
         if get_down_bool:
             if req.page_id is None:
                 raise HTTPException(status_code=400, detail="page_id is required when get_down=true")
-            if not (req.edit_prompt or "").strip():
+            if regenerate_from_outline_bool and not pc:
+                raise HTTPException(status_code=400, detail="pagecontent is required when regenerate_from_outline=true")
+            if not regenerate_from_outline_bool and not (req.edit_prompt or "").strip():
                 raise HTTPException(status_code=400, detail="edit_prompt is required when get_down=true")
         else:
             if not pc:
@@ -325,6 +328,7 @@ class Paper2PPTService:
             get_down=get_down_bool,
             edit_page_num=req.page_id,
             edit_page_prompt=req.edit_prompt,
+            regenerate_from_outline=regenerate_from_outline_bool,
         )
 
         resp_dict = resp_model.model_dump()

--- a/fastapi_app/workflow_adapters/wa_paper2ppt.py
+++ b/fastapi_app/workflow_adapters/wa_paper2ppt.py
@@ -299,6 +299,7 @@ async def run_paper2ppt_wf_api(
     get_down: bool | None = None,
     edit_page_num: int | None = None,
     edit_page_prompt: str | None = None,
+    regenerate_from_outline: bool = False,
     auto_fill_generated_pages: bool = True,
 ) -> Paper2PPTResponse:
     """
@@ -337,6 +338,7 @@ async def run_paper2ppt_wf_api(
             state.edit_page_num = int(edit_page_num)
         if edit_page_prompt is not None:
             state.edit_page_prompt = str(edit_page_prompt)
+        state.regenerate_from_outline = bool(regenerate_from_outline)
 
         if auto_fill_generated_pages and base_dir is not None:
             try:

--- a/frontend-workflow/src/components/paper2ppt/GenerateStep.tsx
+++ b/frontend-workflow/src/components/paper2ppt/GenerateStep.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   FileText, Sparkles, Loader2, MessageSquare, RefreshCw,
-  ArrowLeft, CheckCircle2, AlertCircle
+  ArrowLeft, CheckCircle2, AlertCircle, Plus, Trash2
 } from 'lucide-react';
 import { SlideOutline, GenerateResult, Step } from './types';
 import VersionHistory from './VersionHistory';
@@ -15,6 +15,10 @@ interface GenerateStepProps {
   taskMessage?: string;
   slidePrompt: string;
   setSlidePrompt: (prompt: string) => void;
+  updateCurrentSlideLayout: (value: string) => void;
+  updateCurrentSlideKeyPoint: (index: number, value: string) => void;
+  addCurrentSlideKeyPoint: () => void;
+  removeCurrentSlideKeyPoint: (index: number) => void;
   handleRegenerateSlide: () => void;
   handleConfirmSlide: () => void;
   setCurrentStep: (step: Step) => void;
@@ -31,6 +35,10 @@ const GenerateStep: React.FC<GenerateStepProps> = ({
   taskMessage,
   slidePrompt,
   setSlidePrompt,
+  updateCurrentSlideLayout,
+  updateCurrentSlideKeyPoint,
+  addCurrentSlideKeyPoint,
+  removeCurrentSlideKeyPoint,
   handleRegenerateSlide,
   handleConfirmSlide,
   setCurrentStep,
@@ -61,16 +69,48 @@ const GenerateStep: React.FC<GenerateStepProps> = ({
         <div className="glass rounded-xl border border-white/10 p-4 mb-4">
           <div className="mb-3">
             <h4 className="text-sm text-gray-400 mb-2 flex items-center gap-2"><FileText size={14} className="text-purple-400" /> 布局描述</h4>
-            <p className="text-xs text-purple-400/80 italic">{currentSlide.layout_description}</p>
+            <textarea
+              value={currentSlide.layout_description}
+              onChange={(e) => updateCurrentSlideLayout(e.target.value)}
+              disabled={isGenerating}
+              rows={3}
+              className="w-full px-3 py-2 rounded-lg bg-black/40 border border-white/20 text-sm text-purple-100 outline-none focus:ring-2 focus:ring-purple-500 resize-none disabled:opacity-60"
+              placeholder="直接调整当前页的布局描述..."
+            />
           </div>
           <div className="pt-3 border-t border-white/10">
-            <h4 className="text-sm text-gray-400 mb-2">要点内容</h4>
-            <ul className="grid grid-cols-1 md:grid-cols-2 gap-1">
-              {currentSlide.key_points.slice(0, 4).map((point, idx) => (
-                <li key={idx} className="text-xs text-gray-400 flex items-start gap-1"><span className="text-purple-400">•</span><span className="line-clamp-1">{point}</span></li>
+            <div className="flex items-center justify-between gap-3 mb-2">
+              <h4 className="text-sm text-gray-400">要点内容</h4>
+              <button
+                onClick={addCurrentSlideKeyPoint}
+                disabled={isGenerating}
+                className="px-2.5 py-1.5 rounded-lg bg-white/5 border border-dashed border-white/20 text-xs text-gray-300 hover:text-purple-300 hover:border-purple-400 disabled:opacity-60 flex items-center gap-1"
+              >
+                <Plus size={12} /> 添加要点
+              </button>
+            </div>
+            <div className="space-y-2">
+              {currentSlide.key_points.map((point, idx) => (
+                <div key={`${currentSlide.id}-kp-${idx}`} className="flex gap-2">
+                  <input
+                    type="text"
+                    value={point}
+                    onChange={(e) => updateCurrentSlideKeyPoint(idx, e.target.value)}
+                    disabled={isGenerating}
+                    className="flex-1 px-3 py-2 rounded-lg bg-black/40 border border-white/20 text-sm text-gray-100 outline-none focus:ring-2 focus:ring-purple-500 disabled:opacity-60"
+                    placeholder={`要点 ${idx + 1}`}
+                  />
+                  <button
+                    onClick={() => removeCurrentSlideKeyPoint(idx)}
+                    disabled={isGenerating || currentSlide.key_points.length <= 1}
+                    className="p-2 rounded-lg text-gray-400 hover:text-red-400 hover:bg-red-500/10 disabled:opacity-30"
+                    title="删除该要点"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
               ))}
-              {currentSlide.key_points.length > 4 && (<li className="text-xs text-gray-500 italic">...还有 {currentSlide.key_points.length - 4} 条</li>)}
-            </ul>
+            </div>
           </div>
         </div>
       )}

--- a/frontend-workflow/src/components/paper2ppt/GenerateStep.tsx
+++ b/frontend-workflow/src/components/paper2ppt/GenerateStep.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   FileText, Sparkles, Loader2, MessageSquare, RefreshCw,
-  ArrowLeft, CheckCircle2, AlertCircle, Plus, Trash2
+  ArrowLeft, CheckCircle2, AlertCircle, Plus, Trash2, Pencil, Save, X
 } from 'lucide-react';
 import { SlideOutline, GenerateResult, Step } from './types';
 import VersionHistory from './VersionHistory';
@@ -15,10 +15,8 @@ interface GenerateStepProps {
   taskMessage?: string;
   slidePrompt: string;
   setSlidePrompt: (prompt: string) => void;
-  updateCurrentSlideLayout: (value: string) => void;
-  updateCurrentSlideKeyPoint: (index: number, value: string) => void;
-  addCurrentSlideKeyPoint: () => void;
-  removeCurrentSlideKeyPoint: (index: number) => void;
+  saveCurrentSlideEdits: (layoutDescription: string, keyPoints: string[]) => void;
+  handleRegenerateSlideFromOutline: () => void;
   handleRegenerateSlide: () => void;
   handleConfirmSlide: () => void;
   setCurrentStep: (step: Step) => void;
@@ -35,10 +33,8 @@ const GenerateStep: React.FC<GenerateStepProps> = ({
   taskMessage,
   slidePrompt,
   setSlidePrompt,
-  updateCurrentSlideLayout,
-  updateCurrentSlideKeyPoint,
-  addCurrentSlideKeyPoint,
-  removeCurrentSlideKeyPoint,
+  saveCurrentSlideEdits,
+  handleRegenerateSlideFromOutline,
   handleRegenerateSlide,
   handleConfirmSlide,
   setCurrentStep,
@@ -47,6 +43,55 @@ const GenerateStep: React.FC<GenerateStepProps> = ({
 }) => {
   const currentSlide = outlineData[currentSlideIndex];
   const currentResult = generateResults[currentSlideIndex];
+  const [isEditingSlideMeta, setIsEditingSlideMeta] = useState(false);
+  const [draftLayoutDescription, setDraftLayoutDescription] = useState('');
+  const [draftKeyPoints, setDraftKeyPoints] = useState<string[]>(['']);
+
+  const syncDraftFromCurrentSlide = () => {
+    setDraftLayoutDescription(currentSlide?.layout_description || '');
+    setDraftKeyPoints(currentSlide?.key_points?.length ? [...currentSlide.key_points] : ['']);
+  };
+
+  useEffect(() => {
+    setIsEditingSlideMeta(false);
+    syncDraftFromCurrentSlide();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentSlideIndex, currentSlide?.id]);
+
+  const handleEditStart = () => {
+    syncDraftFromCurrentSlide();
+    setIsEditingSlideMeta(true);
+  };
+
+  const handleEditCancel = () => {
+    syncDraftFromCurrentSlide();
+    setIsEditingSlideMeta(false);
+  };
+
+  const handleEditSave = () => {
+    saveCurrentSlideEdits(
+      draftLayoutDescription,
+      draftKeyPoints.length > 0 ? draftKeyPoints : ['']
+    );
+    setIsEditingSlideMeta(false);
+  };
+
+  const handleDraftKeyPointChange = (index: number, value: string) => {
+    setDraftKeyPoints(prev =>
+      prev.map((point, pointIndex) => (pointIndex === index ? value : point))
+    );
+  };
+
+  const handleAddDraftKeyPoint = () => {
+    setDraftKeyPoints(prev => [...prev, '']);
+  };
+
+  const handleRemoveDraftKeyPoint = (index: number) => {
+    setDraftKeyPoints(prev => {
+      const nextKeyPoints = prev.filter((_, pointIndex) => pointIndex !== index);
+      return nextKeyPoints.length > 0 ? nextKeyPoints : [''];
+    });
+  };
 
   return (
     <div className="max-w-6xl mx-auto">
@@ -67,50 +112,91 @@ const GenerateStep: React.FC<GenerateStepProps> = ({
 
       {currentSlide && (
         <div className="glass rounded-xl border border-white/10 p-4 mb-4">
-          <div className="mb-3">
-            <h4 className="text-sm text-gray-400 mb-2 flex items-center gap-2"><FileText size={14} className="text-purple-400" /> 布局描述</h4>
-            <textarea
-              value={currentSlide.layout_description}
-              onChange={(e) => updateCurrentSlideLayout(e.target.value)}
-              disabled={isGenerating}
-              rows={3}
-              className="w-full px-3 py-2 rounded-lg bg-black/40 border border-white/20 text-sm text-purple-100 outline-none focus:ring-2 focus:ring-purple-500 resize-none disabled:opacity-60"
-              placeholder="直接调整当前页的布局描述..."
-            />
-          </div>
-          <div className="pt-3 border-t border-white/10">
-            <div className="flex items-center justify-between gap-3 mb-2">
-              <h4 className="text-sm text-gray-400">要点内容</h4>
+          <div className="flex items-center justify-between gap-3 mb-3">
+            <h3 className="text-sm font-medium text-white">页面内容</h3>
+            <div className="flex items-center gap-2">
+              {isEditingSlideMeta && (
+                <button
+                  onClick={handleEditCancel}
+                  disabled={isGenerating}
+                  className="p-2 rounded-lg border border-white/15 text-gray-300 hover:text-red-300 hover:border-red-400 hover:bg-white/5 disabled:opacity-50"
+                  title="舍弃当前修改"
+                >
+                  <X size={14} />
+                </button>
+              )}
               <button
-                onClick={addCurrentSlideKeyPoint}
+                onClick={isEditingSlideMeta ? handleEditSave : handleEditStart}
                 disabled={isGenerating}
-                className="px-2.5 py-1.5 rounded-lg bg-white/5 border border-dashed border-white/20 text-xs text-gray-300 hover:text-purple-300 hover:border-purple-400 disabled:opacity-60 flex items-center gap-1"
+                className="p-2 rounded-lg border border-white/15 text-gray-300 hover:text-purple-300 hover:border-purple-400 hover:bg-white/5 disabled:opacity-50"
+                title={isEditingSlideMeta ? '保存当前修改' : '编辑当前页内容'}
               >
-                <Plus size={12} /> 添加要点
+                {isEditingSlideMeta ? <Save size={14} /> : <Pencil size={14} />}
               </button>
             </div>
-            <div className="space-y-2">
-              {currentSlide.key_points.map((point, idx) => (
-                <div key={`${currentSlide.id}-kp-${idx}`} className="flex gap-2">
-                  <input
-                    type="text"
-                    value={point}
-                    onChange={(e) => updateCurrentSlideKeyPoint(idx, e.target.value)}
-                    disabled={isGenerating}
-                    className="flex-1 px-3 py-2 rounded-lg bg-black/40 border border-white/20 text-sm text-gray-100 outline-none focus:ring-2 focus:ring-purple-500 disabled:opacity-60"
-                    placeholder={`要点 ${idx + 1}`}
-                  />
+          </div>
+          <div className="mb-3">
+            <h4 className="text-sm text-gray-400 mb-2 flex items-center gap-2"><FileText size={14} className="text-purple-400" /> 布局描述</h4>
+            {isEditingSlideMeta ? (
+              <textarea
+                value={draftLayoutDescription}
+                onChange={(e) => setDraftLayoutDescription(e.target.value)}
+                disabled={isGenerating}
+                rows={3}
+                className="w-full px-3 py-2 rounded-lg bg-black/40 border border-white/20 text-sm text-purple-100 outline-none focus:ring-2 focus:ring-purple-500 resize-none disabled:opacity-60"
+                placeholder="直接调整当前页的布局描述..."
+              />
+            ) : (
+              <p className="text-xs text-purple-400/80 italic">{currentSlide.layout_description}</p>
+            )}
+          </div>
+          <div className="pt-3 border-t border-white/10">
+            {isEditingSlideMeta ? (
+              <>
+                <div className="flex items-center justify-between gap-3 mb-2">
+                  <h4 className="text-sm text-gray-400">要点内容</h4>
                   <button
-                    onClick={() => removeCurrentSlideKeyPoint(idx)}
-                    disabled={isGenerating || currentSlide.key_points.length <= 1}
-                    className="p-2 rounded-lg text-gray-400 hover:text-red-400 hover:bg-red-500/10 disabled:opacity-30"
-                    title="删除该要点"
+                    onClick={handleAddDraftKeyPoint}
+                    disabled={isGenerating}
+                    className="px-2.5 py-1.5 rounded-lg bg-white/5 border border-dashed border-white/20 text-xs text-gray-300 hover:text-purple-300 hover:border-purple-400 disabled:opacity-60 flex items-center gap-1"
                   >
-                    <Trash2 size={14} />
+                    <Plus size={12} /> 添加要点
                   </button>
                 </div>
-              ))}
-            </div>
+                <div className="space-y-2">
+                  {draftKeyPoints.map((point, idx) => (
+                    <div key={`${currentSlide.id}-kp-${idx}`} className="flex gap-2">
+                      <input
+                        type="text"
+                        value={point}
+                        onChange={(e) => handleDraftKeyPointChange(idx, e.target.value)}
+                        disabled={isGenerating}
+                        className="flex-1 px-3 py-2 rounded-lg bg-black/40 border border-white/20 text-sm text-gray-100 outline-none focus:ring-2 focus:ring-purple-500 disabled:opacity-60"
+                        placeholder={`要点 ${idx + 1}`}
+                      />
+                      <button
+                        onClick={() => handleRemoveDraftKeyPoint(idx)}
+                        disabled={isGenerating || draftKeyPoints.length <= 1}
+                        className="p-2 rounded-lg text-gray-400 hover:text-red-400 hover:bg-red-500/10 disabled:opacity-30"
+                        title="删除该要点"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <>
+                <h4 className="text-sm text-gray-400 mb-2">要点内容</h4>
+                <ul className="grid grid-cols-1 md:grid-cols-2 gap-1">
+                  {currentSlide.key_points.slice(0, 4).map((point, idx) => (
+                    <li key={idx} className="text-xs text-gray-400 flex items-start gap-1"><span className="text-purple-400">•</span><span className="line-clamp-1">{point}</span></li>
+                  ))}
+                  {currentSlide.key_points.length > 4 && (<li className="text-xs text-gray-500 italic">...还有 {currentSlide.key_points.length - 4} 条</li>)}
+                </ul>
+              </>
+            )}
           </div>
         </div>
       )}
@@ -133,6 +219,15 @@ const GenerateStep: React.FC<GenerateStepProps> = ({
               <div className="text-center"><FileText size={32} className="text-gray-500 mx-auto mb-2" /><span className="text-gray-500">等待生成</span></div>
             )}
           </div>
+          <div className="mt-4 flex justify-center">
+            <button
+              onClick={handleRegenerateSlideFromOutline}
+              disabled={isGenerating || isEditingSlideMeta}
+              className="px-5 py-2.5 rounded-lg border border-white/20 text-gray-300 hover:bg-white/10 text-sm flex items-center gap-2 disabled:opacity-50"
+            >
+              <RefreshCw size={14} /> 按当前内容重新生成
+            </button>
+          </div>
         </div>
       </div>
 
@@ -141,22 +236,25 @@ const GenerateStep: React.FC<GenerateStepProps> = ({
           versions={currentResult.versionHistory}
           currentVersionIndex={currentResult.currentVersionIndex}
           onRevert={handleRevertToVersion}
-          isGenerating={isGenerating}
+          isGenerating={isGenerating || isEditingSlideMeta}
         />
       )}
 
       <div className="glass rounded-xl border border-white/10 p-4 mb-6">
         <div className="flex items-center gap-3">
           <MessageSquare size={18} className="text-purple-400" />
-          <input type="text" value={slidePrompt} onChange={e => setSlidePrompt(e.target.value)} placeholder="输入微调 Prompt，然后点击重新生成..." className="flex-1 bg-transparent outline-none text-white text-sm placeholder:text-gray-500" />
-          <button onClick={handleRegenerateSlide} disabled={isGenerating || !slidePrompt.trim()} className="px-4 py-2 rounded-lg bg-white/10 hover:bg-white/20 text-gray-300 text-sm flex items-center gap-2 disabled:opacity-50">
-            <RefreshCw size={14} /> 重新生成
+          <input type="text" value={slidePrompt} onChange={e => setSlidePrompt(e.target.value)} placeholder="输入微调 Prompt，然后点击按提示微调..." disabled={isEditingSlideMeta} className="flex-1 bg-transparent outline-none text-white text-sm placeholder:text-gray-500 disabled:opacity-50" />
+          <button onClick={handleRegenerateSlide} disabled={isGenerating || isEditingSlideMeta || !slidePrompt.trim()} className="px-4 py-2 rounded-lg bg-white/10 hover:bg-white/20 text-gray-300 text-sm flex items-center gap-2 disabled:opacity-50">
+            <RefreshCw size={14} /> 按提示微调
           </button>
         </div>
+        {isEditingSlideMeta && (
+          <p className="mt-3 text-xs text-amber-300">当前正在编辑页面内容，请先选择保存或舍弃更改，再重新生成或切换页面。</p>
+        )}
       </div>
 
       <div className="flex justify-between">
-        <button onClick={() => setCurrentStep('outline')} className="px-6 py-2.5 rounded-lg border border-white/20 text-gray-300 hover:bg-white/10 flex items-center gap-2">
+        <button onClick={() => setCurrentStep('outline')} disabled={isGenerating || isEditingSlideMeta} className="px-6 py-2.5 rounded-lg border border-white/20 text-gray-300 hover:bg-white/10 flex items-center gap-2 disabled:opacity-30">
           <ArrowLeft size={18} /> 返回大纲
         </button>
         <div className="flex gap-3">
@@ -167,12 +265,12 @@ const GenerateStep: React.FC<GenerateStepProps> = ({
                 setSlidePrompt('');
               }
             }}
-            disabled={currentSlideIndex === 0 || isGenerating}
+            disabled={currentSlideIndex === 0 || isGenerating || isEditingSlideMeta}
             className="px-6 py-2.5 rounded-lg border border-white/20 text-gray-300 hover:bg-white/10 flex items-center gap-2 disabled:opacity-30"
           >
             <ArrowLeft size={18} /> 上一页
           </button>
-          <button onClick={handleConfirmSlide} disabled={isGenerating || currentResult?.status !== 'done'} className="px-6 py-2.5 rounded-lg bg-gradient-to-r from-purple-600 to-pink-600 text-white font-semibold flex items-center gap-2 disabled:opacity-50">
+          <button onClick={handleConfirmSlide} disabled={isGenerating || isEditingSlideMeta || currentResult?.status !== 'done'} className="px-6 py-2.5 rounded-lg bg-gradient-to-r from-purple-600 to-pink-600 text-white font-semibold flex items-center gap-2 disabled:opacity-50">
             <CheckCircle2 size={18} /> {currentSlideIndex < outlineData.length - 1 ? '确认并继续' : '完成生成'}
           </button>
         </div>

--- a/frontend-workflow/src/components/paper2ppt/index.tsx
+++ b/frontend-workflow/src/components/paper2ppt/index.tsx
@@ -800,6 +800,50 @@ const Paper2PptPage = () => {
     }
   };
 
+  const updateCurrentSlideLayout = (value: string) => {
+    setOutlineData(prev =>
+      prev.map((slide, index) =>
+        index === currentSlideIndex
+          ? { ...slide, layout_description: value }
+          : slide
+      )
+    );
+  };
+
+  const updateCurrentSlideKeyPoint = (keyPointIndex: number, value: string) => {
+    setOutlineData(prev =>
+      prev.map((slide, slideIndex) => {
+        if (slideIndex !== currentSlideIndex) return slide;
+        const nextKeyPoints = [...slide.key_points];
+        nextKeyPoints[keyPointIndex] = value;
+        return { ...slide, key_points: nextKeyPoints };
+      })
+    );
+  };
+
+  const addCurrentSlideKeyPoint = () => {
+    setOutlineData(prev =>
+      prev.map((slide, index) =>
+        index === currentSlideIndex
+          ? { ...slide, key_points: [...slide.key_points, ''] }
+          : slide
+      )
+    );
+  };
+
+  const removeCurrentSlideKeyPoint = (keyPointIndex: number) => {
+    setOutlineData(prev =>
+      prev.map((slide, slideIndex) => {
+        if (slideIndex !== currentSlideIndex) return slide;
+        const nextKeyPoints = slide.key_points.filter((_, index) => index !== keyPointIndex);
+        return {
+          ...slide,
+          key_points: nextKeyPoints.length > 0 ? nextKeyPoints : [''],
+        };
+      })
+    );
+  };
+
   // ============== 版本历史相关函数 ==============
   const convertToHttpUrl = (path: string): string => {
     // 如果已经是HTTP URL，直接返回
@@ -1290,6 +1334,10 @@ const Paper2PptPage = () => {
               taskMessage={generateTaskMessage}
               slidePrompt={slidePrompt}
               setSlidePrompt={setSlidePrompt}
+              updateCurrentSlideLayout={updateCurrentSlideLayout}
+              updateCurrentSlideKeyPoint={updateCurrentSlideKeyPoint}
+              addCurrentSlideKeyPoint={addCurrentSlideKeyPoint}
+              removeCurrentSlideKeyPoint={removeCurrentSlideKeyPoint}
               handleRegenerateSlide={handleRegenerateSlide}
               handleConfirmSlide={handleConfirmSlide}
               setCurrentStep={setCurrentStep}

--- a/frontend-workflow/src/components/paper2ppt/index.tsx
+++ b/frontend-workflow/src/components/paper2ppt/index.tsx
@@ -800,49 +800,32 @@ const Paper2PptPage = () => {
     }
   };
 
-  const updateCurrentSlideLayout = (value: string) => {
-    setOutlineData(prev =>
-      prev.map((slide, index) =>
-        index === currentSlideIndex
-          ? { ...slide, layout_description: value }
-          : slide
-      )
-    );
-  };
-
-  const updateCurrentSlideKeyPoint = (keyPointIndex: number, value: string) => {
+  const saveCurrentSlideEdits = (layoutDescription: string, keyPoints: string[]) => {
     setOutlineData(prev =>
       prev.map((slide, slideIndex) => {
         if (slideIndex !== currentSlideIndex) return slide;
-        const nextKeyPoints = [...slide.key_points];
-        nextKeyPoints[keyPointIndex] = value;
-        return { ...slide, key_points: nextKeyPoints };
-      })
-    );
-  };
-
-  const addCurrentSlideKeyPoint = () => {
-    setOutlineData(prev =>
-      prev.map((slide, index) =>
-        index === currentSlideIndex
-          ? { ...slide, key_points: [...slide.key_points, ''] }
-          : slide
-      )
-    );
-  };
-
-  const removeCurrentSlideKeyPoint = (keyPointIndex: number) => {
-    setOutlineData(prev =>
-      prev.map((slide, slideIndex) => {
-        if (slideIndex !== currentSlideIndex) return slide;
-        const nextKeyPoints = slide.key_points.filter((_, index) => index !== keyPointIndex);
         return {
           ...slide,
-          key_points: nextKeyPoints.length > 0 ? nextKeyPoints : [''],
+          layout_description: layoutDescription,
+          key_points: keyPoints.length > 0 ? keyPoints : [''],
         };
       })
     );
   };
+
+  const buildPagecontentForGeneration = () => (
+    outlineData.map((slide, idx) => {
+      const result = generateResults[idx];
+      const generatedPath = result?.afterImage || '';
+      return {
+        title: slide.title,
+        layout_description: slide.layout_description,
+        key_points: slide.key_points,
+        asset_ref: slide.asset_ref,
+        generated_img_path: generatedPath || undefined,
+      };
+    })
+  );
 
   // ============== 版本历史相关函数 ==============
   const convertToHttpUrl = (path: string): string => {
@@ -947,6 +930,99 @@ const Paper2PptPage = () => {
   };
 
   // ============== Step 3: 重新生成单页 ==============
+  const handleRegenerateSlideFromOutline = async () => {
+    if (!resultPath) {
+      setError('缺少 result_path，请重新上传文件');
+      return;
+    }
+
+    setIsGenerating(true);
+    setError(null);
+
+    const updatedResults = [...generateResults];
+    updatedResults[currentSlideIndex] = {
+      ...updatedResults[currentSlideIndex],
+      status: 'processing',
+    };
+    setGenerateResults(updatedResults);
+
+    try {
+      const formData = new FormData();
+      formData.append('img_gen_model_name', genFigModel);
+      formData.append('chat_api_url', llmApiUrl.trim());
+      formData.append('api_key', apiKey.trim());
+      formData.append('model', model);
+      formData.append('language', language);
+      formData.append('style', globalPrompt || getStyleDescription(stylePreset));
+      formData.append('aspect_ratio', '16:9');
+      formData.append('email', user?.id || user?.email || '');
+      formData.append('result_path', resultPath);
+      formData.append('get_down', 'true');
+      formData.append('page_id', String(currentSlideIndex));
+      formData.append('regenerate_from_outline', 'true');
+
+      if (styleMode === 'reference' && referenceImage) {
+        formData.append('reference_img', referenceImage);
+        formData.set('style', globalPrompt || '');
+      }
+
+      formData.append('pagecontent', JSON.stringify(buildPagecontentForGeneration()));
+
+      const res = await fetch('/api/v1/paper2ppt/generate', {
+        method: 'POST',
+        headers: { 'X-API-Key': API_KEY },
+        body: formData,
+      });
+
+      if (!res.ok) {
+        let msg = '服务器繁忙，请稍后再试';
+        if (res.status === 429) {
+          msg = '请求过于频繁，请稍后再试';
+        } else {
+          try {
+            const errBody = await res.json();
+            if (errBody?.error) msg = errBody.error;
+          } catch { /* ignore parse error */ }
+        }
+        throw new Error(msg);
+      }
+
+      const data = await res.json();
+      if (!data.success) {
+        throw new Error(data.error || '服务器繁忙，请稍后再试');
+      }
+
+      const pageNumStr = String(currentSlideIndex).padStart(3, '0');
+      let afterImage = updatedResults[currentSlideIndex].afterImage;
+      if (data.all_output_files && Array.isArray(data.all_output_files)) {
+        const pageImg = data.all_output_files.find((url: string) =>
+          url.includes(`ppt_pages/page_${pageNumStr}.png`)
+        );
+        if (pageImg) {
+          afterImage = pageImg + '?t=' + Date.now();
+        }
+      }
+
+      updatedResults[currentSlideIndex] = {
+        ...updatedResults[currentSlideIndex],
+        afterImage,
+        status: 'done',
+      };
+      setGenerateResults([...updatedResults]);
+      await fetchVersionHistory(currentSlideIndex);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '服务器繁忙，请稍后再试';
+      setError(message);
+      updatedResults[currentSlideIndex] = {
+        ...updatedResults[currentSlideIndex],
+        status: 'done',
+      };
+      setGenerateResults([...updatedResults]);
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
   const handleRegenerateSlide = async () => {
     if (!resultPath) {
       setError('缺少 result_path，请重新上传文件');
@@ -990,21 +1066,7 @@ const Paper2PptPage = () => {
         formData.set('style', globalPrompt || '');
       }
 
-      const pagecontent = outlineData.map((slide, idx) => {
-        const result = generateResults[idx];
-        let generatedPath = '';
-        if (result?.afterImage) {
-          generatedPath = result.afterImage;
-        }
-        console.log(`[handleRegenerateSlide] 页面${idx}: afterImage=${result?.afterImage}, generatedPath=${generatedPath}`);
-        return {
-          title: slide.title,
-          layout_description: slide.layout_description,
-          key_points: slide.key_points,
-          asset_ref: slide.asset_ref,
-          generated_img_path: generatedPath || undefined,
-        };
-      });
+      const pagecontent = buildPagecontentForGeneration();
       console.log(`[handleRegenerateSlide] 当前编辑页面: ${currentSlideIndex}`);
       console.log(`[handleRegenerateSlide] 完整pagecontent:`, JSON.stringify(pagecontent.map((p, i) => ({
         idx: i,
@@ -1334,10 +1396,8 @@ const Paper2PptPage = () => {
               taskMessage={generateTaskMessage}
               slidePrompt={slidePrompt}
               setSlidePrompt={setSlidePrompt}
-              updateCurrentSlideLayout={updateCurrentSlideLayout}
-              updateCurrentSlideKeyPoint={updateCurrentSlideKeyPoint}
-              addCurrentSlideKeyPoint={addCurrentSlideKeyPoint}
-              removeCurrentSlideKeyPoint={removeCurrentSlideKeyPoint}
+              saveCurrentSlideEdits={saveCurrentSlideEdits}
+              handleRegenerateSlideFromOutline={handleRegenerateSlideFromOutline}
               handleRegenerateSlide={handleRegenerateSlide}
               handleConfirmSlide={handleConfirmSlide}
               setCurrentStep={setCurrentStep}


### PR DESCRIPTION
## Summary
- keep the paper2ppt generate step read-only by default and only enter editing after clicking the edit icon
- add explicit save/discard behavior for layout description and key points instead of real-time writes while typing
- add a separate "按当前内容重新生成" action that regenerates the current slide from saved page content
- keep the original prompt-based flow as a separate "按提示微调" action for image refinement
- route content-based regeneration through the existing `/paper2ppt/generate` API with a new `regenerate_from_outline=true` mode instead of adding a new endpoint

## Details
- frontend generate step now uses local draft state for page content edits and blocks page switching/regeneration until the draft is saved or discarded
- content-based regeneration sends the latest saved `layout_description` and `key_points` in `pagecontent` and regenerates only the current page
- prompt-based regeneration still edits from the existing generated image, so its behavior remains independent from the new content-regeneration path
- the content-regeneration button is placed under the generated image preview and centered to make it clearly distinct from the prompt refinement box

## Verification
- `python3 -m py_compile fastapi_app/schemas.py fastapi_app/routers/paper2ppt.py fastapi_app/services/paper2ppt_service.py fastapi_app/workflow_adapters/wa_paper2ppt.py dataflow_agent/state.py dataflow_agent/workflow/wf_paper2ppt_parallel_consistent_style.py`
- `npm run build`