### PR TITLE
Update README with desktop release link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ English | [中文](README_CN.md)
 > 🆕 <strong>2026-06-13 · Paper to Any Studio / Nexus Upgrade</strong><br>
 > The online version is being upgraded to the new <strong>Paper to Any Studio</strong> experience, with a unified Studio workspace, Spaces for personal/project/team files, Labs apps, online Office previews, Credits visibility, and cleaner long-running workflows.<br>
 > 🌐 New public entry: <a href="https://paper2any-studio.cpolar.cn/" target="_blank"><strong>https://paper2any-studio.cpolar.cn/</strong></a><br>
+> 💻 Mac desktop releases: <a href="https://github.com/DeepThinkingZhouLiu/Paper2Any-Desktop-Releases" target="_blank"><strong>Paper2Any-Desktop-Releases</strong></a> · public DMG artifacts only; source code remains private/commercial.<br>
 > ⚠️ The public entry is a hosted Studio / Nexus experience and is not identical to the open-source code in this repository. The commercial Studio implementation is not fully open-sourced here.<br>
 > 📢 Full update notice: <a href="https://wcny4qa9krto.feishu.cn/wiki/IjBSwlz6AiPTItkw91GcyZCKnyg" target="_blank"><strong>Paper to Any Studio New Version Update Notice</strong></a>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -67,6 +67,7 @@
 > 🆕 <strong>2026-06-13 · Paper to Any Studio / Nexus 新版本升级</strong><br>
 > 线上版本正在升级为全新的 <strong>Paper to Any Studio</strong> 形态，新增统一 Studio 工作台、个人/项目/团队文件空间、应用实验室、Office 在线预览、Credits 消耗提示和更清晰的长任务体验。<br>
 > 🌐 新版公网入口：<a href="https://paper2any-studio.cpolar.cn/" target="_blank"><strong>https://paper2any-studio.cpolar.cn/</strong></a><br>
+> 💻 Mac 桌面端下载：<a href="https://github.com/DeepThinkingZhouLiu/Paper2Any-Desktop-Releases" target="_blank"><strong>Paper2Any-Desktop-Releases</strong></a> · 该公开仓库仅放 DMG 编译产物，商业版源码不在此开源。<br>
 > ⚠️ 该公网入口展示的是托管版 Studio / Nexus 体验，和本开源仓库代码不完全一致；完整商业版 Studio 实现并未在此仓库开源。<br>
 > 📢 完整更新通知：<a href="https://wcny4qa9krto.feishu.cn/wiki/Uq9rwqg5hi7G0RkGBq2cYyuxnie" target="_blank"><strong>Paper to Any Studio 新版本更新通知</strong></a>
 


### PR DESCRIPTION
## Summary
- add the public Paper2Any Desktop Releases repository link to English and Chinese README news sections
- clarify that the desktop release repository only hosts compiled DMG artifacts and does not open-source the commercial Studio code

## Verification
- git diff --check