### PR TITLE
fix(docker): declare NGINX_BASE_IMAGE before first FROM for BuildKit

### DIFF
--- a/frontend-workflow/Dockerfile
+++ b/frontend-workflow/Dockerfile
@@ -1,4 +1,5 @@
 ARG NODE_BASE_IMAGE=node:20-alpine
+ARG NGINX_BASE_IMAGE=nginx:alpine
 FROM ${NODE_BASE_IMAGE} AS build
 
 ARG VITE_API_KEY=
@@ -28,7 +29,7 @@ RUN cp -f .env.example .env.production || true && \
 
 RUN npm run build
 
-ARG NGINX_BASE_IMAGE=nginx:alpine
+ARG NGINX_BASE_IMAGE
 FROM ${NGINX_BASE_IMAGE}
 
 COPY frontend-workflow/nginx.conf.template /etc/nginx/templates/default.conf.template


### PR DESCRIPTION
## What changed

Moved the `ARG NGINX_BASE_IMAGE` declaration in `frontend-workflow/Dockerfile` from inside the node build stage to the global scope (before the first `FROM`), keeping the same `nginx:alpine` default.

## Why

ARGs referenced by a `FROM` instruction must be declared in the global scope. The previous placement (inside the `build` stage, line 31) is out of scope for the following `FROM ${NGINX_BASE_IMAGE}`, so newer BuildKit / Docker Compose versions resolve it as blank and the frontend image build fails:

```
#3 WARN: UndefinedArgInFrom: FROM argument 'NGINX_BASE_IMAGE' is not declared (line 32)
target paper2any-frontend: failed to solve: base name (${NGINX_BASE_IMAGE}) should not be blank
```

Reproduced with Docker Desktop 4.81 (Docker 29.6.1, Compose v5.2.0) on Windows running `bash deploy/docker-up.sh`.

## Notes for reviewers

- Behavior is unchanged for builds that pass `NGINX_BASE_IMAGE` explicitly (e.g. via `deploy/docker.env`); this only fixes the default resolution.
- `NODE_BASE_IMAGE` was already declared globally, so only the nginx ARG needed moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)